### PR TITLE
Connections interface fixes

### DIFF
--- a/js/rowmanager.js
+++ b/js/rowmanager.js
@@ -129,7 +129,7 @@ SQL.RowManager.prototype.foreigndisconnect = function(e) { /* remove connector *
 	var rels = this.selected.relations;
 	for (var i=rels.length-1;i>=0;i--) {
 		var r = rels[i];
-		if (r.row2 == this.selected) { this.owner.removeRelation(r); }
+		if (r.row2 == this.selected || r.row1 == this.selected) { this.owner.removeRelation(r); }
 	}
 	this.redraw();
 }
@@ -182,7 +182,7 @@ SQL.RowManager.prototype.redraw = function() {
 		var rels = this.selected.relations;
 		for (var i=0;i<rels.length;i++) {
 			var r = rels[i];
-			if (r.row2 == this.selected) { this.dom.foreigndisconnect.disabled = false; }
+			if (r.row2 == this.selected || r.row1 == this.selected) { this.dom.foreigndisconnect.disabled = false; }
 		}
 
 	} else {

--- a/js/rowmanager.js
+++ b/js/rowmanager.js
@@ -57,6 +57,15 @@ SQL.RowManager.prototype.tableClick = function(e) { /* create relation after cli
 }
 
 SQL.RowManager.prototype.rowClick = function(e) { /* draw relation after clicking target row */
+	if (this.creating_no_data) {
+		if (!e.target.isUnique()) { return; }
+
+		this.selected = e.target;
+		this.selected.select();
+		this.creating = true
+		this.creating_no_data = false;
+	}
+
 	if (this.connecting_no_data) {
 		this.selected = e.target;
 		this.selected.select();
@@ -80,11 +89,20 @@ SQL.RowManager.prototype.rowClick = function(e) { /* draw relation after clickin
 
 SQL.RowManager.prototype.foreigncreate = function(e) { /* start creating fk */
 	this.endConnect();
-	if (this.creating) {
-		this.endCreate();
+	if (this.selected) {
+		if (this.creating) {
+			this.endCreate();
+		} else {
+			this.creating = true;
+			this.dom.foreigncreate.value = "["+_("foreignpending")+"]";
+		}
 	} else {
-		this.creating = true;
-		this.dom.foreigncreate.value = "["+_("foreignpending")+"]";
+		if (this.creating) {
+			this.endCreate();
+		} else {
+			this.creating_no_data = true;
+			this.dom.foreigncreate.value = "["+_("foreignconnectpending")+"]";
+		}
 	}
 }
 

--- a/js/rowmanager.js
+++ b/js/rowmanager.js
@@ -175,8 +175,8 @@ SQL.RowManager.prototype.redraw = function() {
 		this.dom.downrow.disabled = (rows[rows.length-1] == this.selected);
 		this.dom.removerow.disabled = false;
 		this.dom.editrow.disabled = false;
-		// this.dom.foreigncreate.disabled = !(this.selected.isUnique());
-		// this.dom.foreignconnect.disabled = !(this.selected.isUnique());
+		this.dom.foreigncreate.disabled = this.owner.tables.length < 2;
+		this.dom.foreignconnect.disabled = this.owner.tables.length < 2;
 
 		this.dom.foreigndisconnect.disabled = true;
 		var rels = this.selected.relations;
@@ -190,8 +190,8 @@ SQL.RowManager.prototype.redraw = function() {
 		this.dom.downrow.disabled = true;
 		this.dom.removerow.disabled = true;
 		this.dom.editrow.disabled = true;
-		// this.dom.foreigncreate.disabled = true;
-		// this.dom.foreignconnect.disabled = true;
+		this.dom.foreigncreate.disabled = this.owner.tables.length < 2;
+		this.dom.foreignconnect.disabled = this.owner.tables.length < 2;
 		this.dom.foreigndisconnect.disabled = true;
 	}
 }

--- a/js/rowmanager.js
+++ b/js/rowmanager.js
@@ -5,7 +5,8 @@ SQL.RowManager = function(owner) {
 	this.selected = null;
 	this.creating = false;
 	this.connecting = false;
-	
+	this.connecting_no_data = false;
+
 	var ids = ["editrow","removerow","uprow","downrow","foreigncreate","foreignconnect","foreigndisconnect"];
 	for (var i=0;i<ids.length;i++) {
 		var id = ids[i];
@@ -15,7 +16,7 @@ SQL.RowManager = function(owner) {
 	}
 
 	this.select(false);
-	
+
 	OZ.Event.add(this.dom.editrow, "click", this.edit.bind(this));
 	OZ.Event.add(this.dom.uprow, "click", this.up.bind(this));
 	OZ.Event.add(this.dom.downrow, "click", this.down.bind(this));
@@ -40,15 +41,15 @@ SQL.RowManager.prototype.select = function(row) { /* activate a row */
 
 SQL.RowManager.prototype.tableClick = function(e) { /* create relation after clicking target table */
 	if (!this.creating) { return; }
-	
+
 	var r1 = this.selected;
 	var t2 = e.target;
-	
+
 	var p = this.owner.getOption("pattern");
 	p = p.replace(/%T/g,r1.owner.getTitle());
 	p = p.replace(/%t/g,t2.getTitle());
 	p = p.replace(/%R/g,r1.getTitle());
-	
+
 	var r2 = t2.addRow(p, r1.data);
 	r2.update({"type":SQL.Designer.getFKTypeFor(r1.data.type)});
 	r2.update({"ai":false});
@@ -56,13 +57,24 @@ SQL.RowManager.prototype.tableClick = function(e) { /* create relation after cli
 }
 
 SQL.RowManager.prototype.rowClick = function(e) { /* draw relation after clicking target row */
+	if (this.connecting_no_data) {
+		this.selected = e.target;
+		this.selected.select();
+		this.connecting = true;
+		this.connecting_no_data = false;
+		return;
+	}
+
 	if (!this.connecting) { return; }
-	
+
 	var r1 = this.selected;
 	var r2 = e.target;
-	
+
 	if (r1 == r2) { return; }
-	
+	var bothAreUnique = r1.isUnique() && r2.isUnique()
+	var neitherAreUnique = !r1.isUnique() && !r2.isUnique()
+	if (bothAreUnique || neitherAreUnique) { return; } // exactly one must be unique
+
 	this.owner.addRelation(r1, r2);
 }
 
@@ -78,11 +90,20 @@ SQL.RowManager.prototype.foreigncreate = function(e) { /* start creating fk */
 
 SQL.RowManager.prototype.foreignconnect = function(e) { /* start drawing fk */
 	this.endCreate();
-	if (this.connecting) {
-		this.endConnect();
+	if (this.selected) {
+		if (this.connecting) {
+			this.endConnect();
+		} else {
+			this.connecting = true;
+			this.dom.foreignconnect.value = "["+_("foreignconnectpending")+"]";
+		}
 	} else {
-		this.connecting = true;
-		this.dom.foreignconnect.value = "["+_("foreignconnectpending")+"]";
+		if (this.connecting) {
+			this.endConnect();
+		} else {
+			this.connecting_no_data = true;
+			this.dom.foreignconnect.value = "["+_("foreignconnectpending")+"]";
+		}
 	}
 }
 
@@ -120,7 +141,7 @@ SQL.RowManager.prototype.remove = function(e) {
 	if (!result) { return; }
 	var t = this.selected.owner;
 	this.selected.owner.removeRow(this.selected);
-	
+
 	var next = false;
 	if (t.rows) { next = t.rows[t.rows.length-1]; }
 	this.select(next);
@@ -136,49 +157,49 @@ SQL.RowManager.prototype.redraw = function() {
 		this.dom.downrow.disabled = (rows[rows.length-1] == this.selected);
 		this.dom.removerow.disabled = false;
 		this.dom.editrow.disabled = false;
-		this.dom.foreigncreate.disabled = !(this.selected.isUnique());
-		this.dom.foreignconnect.disabled = !(this.selected.isUnique());
-		
+		// this.dom.foreigncreate.disabled = !(this.selected.isUnique());
+		// this.dom.foreignconnect.disabled = !(this.selected.isUnique());
+
 		this.dom.foreigndisconnect.disabled = true;
 		var rels = this.selected.relations;
 		for (var i=0;i<rels.length;i++) {
 			var r = rels[i];
 			if (r.row2 == this.selected) { this.dom.foreigndisconnect.disabled = false; }
 		}
-		
+
 	} else {
 		this.dom.uprow.disabled = true;
 		this.dom.downrow.disabled = true;
 		this.dom.removerow.disabled = true;
 		this.dom.editrow.disabled = true;
-		this.dom.foreigncreate.disabled = true;
-		this.dom.foreignconnect.disabled = true;
+		// this.dom.foreigncreate.disabled = true;
+		// this.dom.foreignconnect.disabled = true;
 		this.dom.foreigndisconnect.disabled = true;
 	}
 }
 
 SQL.RowManager.prototype.press = function(e) {
 	if (!this.selected) { return; }
-	
+
 	var target = OZ.Event.target(e).nodeName.toLowerCase();
 	if (target == "textarea" || target == "input") { return; } /* not when in form field */
-	
+
 	switch (e.keyCode) {
 		case 38:
-			this.up();
-			OZ.Event.prevent(e);
+		this.up();
+		OZ.Event.prevent(e);
 		break;
 		case 40:
-			this.down();
-			OZ.Event.prevent(e);
+		this.down();
+		OZ.Event.prevent(e);
 		break;
 		case 46:
-			this.remove();
-			OZ.Event.prevent(e);
+		this.remove();
+		OZ.Event.prevent(e);
 		break;
 		case 13:
 		case 27:
-			this.selected.collapse();
+		this.selected.collapse();
 		break;
 	}
 }


### PR DESCRIPTION
This makes it so you can press the create/connect foreign key buttons anytime (probably should find a way to make sure there are at least 2 tables, but that was more complicated). Also allows you to hit remove foreign key from either the id or the connected field.